### PR TITLE
release: v0.6.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@rollup/plugin-typescript": "^11.1.1",
     "@sindresorhus/tsconfig": "^3.0.1",
     "@technote-space/github-action-test-helper": "^0.11.15",
-    "@types/node": "^20.2.1",
+    "@types/node": "^20.2.3",
     "@typescript-eslint/eslint-plugin": "^5.59.6",
     "@typescript-eslint/parser": "^5.59.6",
     "@vitest/coverage-c8": "^0.31.1",
@@ -65,7 +65,7 @@
     "lint-staged": "^13.2.2",
     "nock": "^13.3.1",
     "pinst": "^3.0.0",
-    "rollup": "^3.22.0",
+    "rollup": "^3.23.0",
     "typescript": "^5.0.4",
     "vitest": "^0.31.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@technote-space/github-action-version-helper",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "Version helper for GitHub Actions.",
   "keywords": [
     "github",

--- a/yarn.lock
+++ b/yarn.lock
@@ -672,10 +672,10 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/node@*", "@types/node@^20.2.1":
-  version "20.2.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.2.1.tgz#de559d4b33be9a808fd43372ccee822c70f39704"
-  integrity sha512-DqJociPbZP1lbZ5SQPk4oag6W7AyaGMO6gSfRwq3PWl4PXTwJpRQJhDq4W0kzrg3w6tJ1SwlvGZ5uKFHY13LIg==
+"@types/node@*", "@types/node@^20.2.3":
+  version "20.2.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.2.3.tgz#b31eb300610c3835ac008d690de6f87e28f9b878"
+  integrity sha512-pg9d0yC4rVNWQzX8U7xb4olIOFuuVL9za3bzMT2pu2SU0SNEi66i2qrvhE2qt0HvkhuCaWJu7pLNOt/Pj8BIrw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -3055,10 +3055,10 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-rollup@^3.21.0, rollup@^3.22.0:
-  version "3.22.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.22.0.tgz#e6671baebdd473154ac7998bbc57faabcd7bba20"
-  integrity sha512-imsigcWor5Y/dC0rz2q0bBt9PabcL3TORry2hAa6O6BuMvY71bqHyfReAz5qyAqiQATD1m70qdntqBfBQjVWpQ==
+rollup@^3.21.0, rollup@^3.23.0:
+  version "3.23.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.23.0.tgz#b8d6146dac4bf058ee817f92820988e9b358b564"
+  integrity sha512-h31UlwEi7FHihLe1zbk+3Q7z1k/84rb9BSwmBSr/XjOCEaBJ2YyedQDuM0t/kfOS0IxM+vk1/zI9XxYj9V+NJQ==
   optionalDependencies:
     fsevents "~2.3.2"
 


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update npm dependencies (4e15d039d6d771e503574a239fb30aa0182a2d1e)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/technote-space/github-action-version-helper/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>cli.js -u --packageFile package.json</em></summary>

```Shell
Using yarn
Upgrading /home/runner/work/github-action-version-helper/github-action-version-helper/package.json

 @types/node  ^20.2.1  →  ^20.2.3
 rollup       ^3.22.0  →  ^3.23.0

Run yarn install to install new versions.
```



</details>
<details>
<summary><em>yarn install</em></summary>

```Shell
yarn install v1.22.19
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
$ [ -n "$CI" ] || [ ! -f node_modules/.bin/husky ] || husky install
Done in 13.97s.
```



</details>
<details>
<summary><em>yarn upgrade</em></summary>

```Shell
yarn upgrade v1.22.19
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
success Saved 347 new dependencies.
info Direct dependencies
├─ @commitlint/cli@17.6.3
├─ @commitlint/config-conventional@17.6.3
├─ @octokit/types@9.2.3
├─ @rollup/plugin-typescript@11.1.1
├─ @sindresorhus/tsconfig@3.0.1
├─ @technote-space/github-action-helper@5.3.15
├─ @technote-space/github-action-test-helper@0.11.15
├─ @types/node@20.2.3
├─ @typescript-eslint/eslint-plugin@5.59.6
├─ @typescript-eslint/parser@5.59.6
├─ @vitest/coverage-c8@0.31.1
├─ eslint-plugin-import@2.27.5
├─ eslint@8.41.0
├─ husky@8.0.3
├─ lint-staged@13.2.2
├─ nock@13.3.1
├─ pinst@3.0.0
├─ rollup@3.23.0
└─ typescript@5.0.4
info All dependencies
├─ @ampproject/remapping@2.2.1
├─ @babel/code-frame@7.21.4
├─ @babel/helper-validator-identifier@7.19.1
├─ @babel/highlight@7.18.6
├─ @bcoe/v8-coverage@0.2.3
├─ @commitlint/cli@17.6.3
├─ @commitlint/config-conventional@17.6.3
├─ @commitlint/ensure@17.4.4
├─ @commitlint/execute-rule@17.4.0
├─ @commitlint/format@17.4.4
├─ @commitlint/is-ignored@17.6.3
├─ @commitlint/lint@17.6.3
├─ @commitlint/load@17.5.0
├─ @commitlint/message@17.4.2
├─ @commitlint/parse@17.4.4
├─ @commitlint/read@17.5.1
├─ @commitlint/resolve-extends@17.4.4
├─ @commitlint/rules@17.6.1
├─ @commitlint/to-lines@17.4.0
├─ @commitlint/top-level@17.4.0
├─ @cspotcode/source-map-support@0.8.1
├─ @esbuild/linux-x64@0.17.19
├─ @eslint/eslintrc@2.0.3
├─ @eslint/js@8.41.0
├─ @humanwhocodes/config-array@0.11.8
├─ @humanwhocodes/module-importer@1.0.1
├─ @humanwhocodes/object-schema@1.2.1
├─ @istanbuljs/schema@0.1.3
├─ @jridgewell/gen-mapping@0.3.3
├─ @jridgewell/resolve-uri@3.1.0
├─ @jridgewell/set-array@1.1.2
├─ @nodelib/fs.scandir@2.1.5
├─ @nodelib/fs.stat@2.0.5
├─ @nodelib/fs.walk@1.2.8
├─ @octokit/auth-token@2.5.0
├─ @octokit/core@3.6.0
├─ @octokit/endpoint@6.0.12
├─ @octokit/graphql@4.8.0
├─ @octokit/plugin-paginate-rest@2.21.3
├─ @octokit/plugin-rest-endpoint-methods@5.16.2
├─ @octokit/request-error@2.1.0
├─ @octokit/request@5.6.3
├─ @octokit/types@9.2.3
├─ @rollup/plugin-typescript@11.1.1
├─ @rollup/pluginutils@5.0.2
├─ @sindresorhus/tsconfig@3.0.1
├─ @technote-space/github-action-helper@5.3.15
├─ @technote-space/github-action-test-helper@0.11.15
├─ @tsconfig/node10@1.0.9
├─ @tsconfig/node12@1.0.11
├─ @tsconfig/node14@1.0.3
├─ @tsconfig/node16@1.0.4
├─ @types/chai-subset@1.3.3
├─ @types/chai@4.3.5
├─ @types/estree@1.0.1
├─ @types/istanbul-lib-coverage@2.0.4
├─ @types/json-schema@7.0.11
├─ @types/json5@0.0.29
├─ @types/minimist@1.2.2
├─ @types/node@20.2.3
├─ @types/normalize-package-data@2.4.1
├─ @types/semver@7.5.0
├─ @typescript-eslint/eslint-plugin@5.59.6
├─ @typescript-eslint/parser@5.59.6
├─ @typescript-eslint/type-utils@5.59.6
├─ @vitest/coverage-c8@0.31.1
├─ @vitest/expect@0.31.1
├─ @vitest/runner@0.31.1
├─ @vitest/snapshot@0.31.1
├─ acorn-jsx@5.3.2
├─ acorn-walk@8.2.0
├─ acorn@8.8.2
├─ aggregate-error@3.1.0
├─ ajv@6.12.6
├─ ansi-escapes@4.3.2
├─ arg@4.1.3
├─ argparse@2.0.1
├─ array-buffer-byte-length@1.0.0
├─ array-ify@1.0.0
├─ array-includes@3.1.6
├─ array-union@2.1.0
├─ array.prototype.flat@1.3.1
├─ array.prototype.flatmap@1.3.1
├─ arrify@1.0.1
├─ assertion-error@1.1.0
├─ balanced-match@1.0.2
├─ before-after-hook@2.2.3
├─ blueimp-md5@2.19.0
├─ brace-expansion@1.1.11
├─ braces@3.0.2
├─ c8@7.13.0
├─ callsites@3.1.0
├─ camelcase-keys@6.2.2
├─ camelcase@5.3.1
├─ chalk@4.1.2
├─ check-error@1.0.2
├─ clean-stack@2.2.0
├─ cli-cursor@3.1.0
├─ cli-truncate@3.1.0
├─ cliui@8.0.1
├─ color-convert@2.0.1
├─ color-name@1.1.4
├─ colorette@2.0.20
├─ commander@10.0.1
├─ concat-map@0.0.1
├─ conventional-changelog-angular@5.0.13
├─ conventional-changelog-conventionalcommits@5.0.0
├─ conventional-commits-parser@3.2.4
├─ convert-source-map@1.9.0
├─ cosmiconfig-typescript-loader@4.3.0
├─ cosmiconfig@8.1.3
├─ create-require@1.1.1
├─ dargs@7.0.0
├─ date-time@3.1.0
├─ debug@4.3.4
├─ decamelize-keys@1.1.1
├─ decamelize@1.2.0
├─ deep-eql@4.1.3
├─ deep-is@0.1.4
├─ deprecation@2.3.1
├─ diff@4.0.2
├─ dir-glob@3.0.1
├─ doctrine@2.1.0
├─ dot-prop@5.3.0
├─ eastasianwidth@0.2.0
├─ emoji-regex@8.0.0
├─ error-ex@1.3.2
├─ es-set-tostringtag@2.0.1
├─ es-to-primitive@1.2.1
├─ esbuild@0.17.19
├─ escape-string-regexp@4.0.0
├─ eslint-import-resolver-node@0.3.7
├─ eslint-module-utils@2.8.0
├─ eslint-plugin-import@2.27.5
├─ eslint-scope@7.2.0
├─ eslint@8.41.0
├─ esquery@1.5.0
├─ estraverse@5.3.0
├─ estree-walker@2.0.2
├─ fast-diff@1.3.0
├─ fast-glob@3.2.12
├─ fast-json-stable-stringify@2.1.0
├─ fast-levenshtein@2.0.6
├─ fastq@1.15.0
├─ file-entry-cache@6.0.1
├─ fill-range@7.0.1
├─ flat-cache@3.0.4
├─ flatted@3.2.7
├─ foreground-child@2.0.0
├─ fs-extra@11.1.1
├─ fs.realpath@1.0.0
├─ function.prototype.name@1.1.5
├─ functions-have-names@1.2.3
├─ get-stream@6.0.1
├─ get-symbol-description@1.0.0
├─ git-raw-commits@2.0.11
├─ glob-parent@6.0.2
├─ glob@7.2.3
├─ global-dirs@0.1.1
├─ globalthis@1.0.3
├─ globby@11.1.0
├─ graceful-fs@4.2.11
├─ grapheme-splitter@1.0.4
├─ graphemer@1.4.0
├─ hard-rejection@2.1.0
├─ has-bigints@1.0.2
├─ has-flag@4.0.0
├─ hosted-git-info@4.1.0
├─ html-escaper@2.0.2
├─ human-signals@2.1.0
├─ husky@8.0.3
├─ imurmurhash@0.1.4
├─ inflight@1.0.6
├─ inherits@2.0.4
├─ ini@1.3.8
├─ internal-slot@1.0.5
├─ is-array-buffer@3.0.2
├─ is-arrayish@0.2.1
├─ is-bigint@1.0.4
├─ is-boolean-object@1.1.2
├─ is-callable@1.2.7
├─ is-date-object@1.0.5
├─ is-extglob@2.1.1
├─ is-negative-zero@2.0.2
├─ is-number-object@1.0.7
├─ is-number@7.0.0
├─ is-obj@2.0.0
├─ is-path-inside@3.0.3
├─ is-plain-obj@1.1.0
├─ is-shared-array-buffer@1.0.2
├─ is-stream@2.0.1
├─ is-string@1.0.7
├─ is-symbol@1.0.4
├─ is-text-path@1.0.1
├─ is-weakref@1.0.2
├─ isexe@2.0.0
├─ istanbul-lib-coverage@3.2.0
├─ istanbul-reports@3.1.5
├─ js-string-escape@1.0.1
├─ js-tokens@4.0.0
├─ json-parse-even-better-errors@2.3.1
├─ json-schema-traverse@0.4.1
├─ json-stable-stringify-without-jsonify@1.0.1
├─ json-stringify-safe@5.0.1
├─ json5@1.0.2
├─ jsonc-parser@3.2.0
├─ jsonfile@6.1.0
├─ jsonparse@1.3.1
├─ JSONStream@1.3.5
├─ kind-of@6.0.3
├─ lilconfig@2.1.0
├─ lines-and-columns@1.2.4
├─ lint-staged@13.2.2
├─ listr2@5.0.8
├─ local-pkg@0.4.3
├─ locate-path@6.0.0
├─ lodash.camelcase@4.3.0
├─ lodash.isfunction@3.0.9
├─ lodash.isplainobject@4.0.6
├─ lodash.kebabcase@4.1.1
├─ lodash.mergewith@4.6.2
├─ lodash.snakecase@4.1.1
├─ lodash.startcase@4.4.0
├─ lodash.uniq@4.5.0
├─ lodash.upperfirst@4.3.1
├─ lodash@4.17.21
├─ log-update@4.0.0
├─ loupe@2.3.6
├─ make-dir@3.1.0
├─ make-error@1.3.6
├─ map-obj@1.0.1
├─ md5-hex@3.0.1
├─ merge2@1.4.1
├─ micromatch@4.0.5
├─ mimic-fn@2.1.0
├─ min-indent@1.0.1
├─ minimist-options@4.1.0
├─ minimist@1.2.8
├─ ms@2.1.2
├─ nanoid@3.3.6
├─ natural-compare-lite@1.4.0
├─ natural-compare@1.4.0
├─ nock@13.3.1
├─ node-fetch@2.6.11
├─ normalize-package-data@3.0.3
├─ normalize-path@3.0.0
├─ npm-run-path@4.0.1
├─ object.assign@4.1.4
├─ object.values@1.1.6
├─ onetime@5.1.2
├─ optionator@0.9.1
├─ p-limit@4.0.0
├─ p-locate@5.0.0
├─ p-map@4.0.0
├─ p-try@2.2.0
├─ parent-module@1.0.1
├─ path-is-absolute@1.0.1
├─ path-key@3.1.1
├─ path-parse@1.0.7
├─ pathval@1.1.1
├─ pidtree@0.6.0
├─ pinst@3.0.0
├─ pkg-types@1.0.3
├─ postcss@8.4.23
├─ propagate@2.0.1
├─ punycode@2.3.0
├─ queue-microtask@1.2.3
├─ quick-lru@4.0.1
├─ react-is@17.0.2
├─ read-pkg-up@7.0.1
├─ read-pkg@5.2.0
├─ readable-stream@3.6.2
├─ redent@3.0.0
├─ regexp.prototype.flags@1.5.0
├─ require-from-string@2.0.2
├─ resolve-global@1.0.0
├─ restore-cursor@3.1.0
├─ reusify@1.0.4
├─ rfdc@1.3.0
├─ rollup@3.23.0
├─ run-parallel@1.2.0
├─ rxjs@7.8.1
├─ safe-buffer@5.2.1
├─ safe-regex-test@1.0.0
├─ shebang-command@2.0.0
├─ shebang-regex@3.0.0
├─ shell-escape@0.2.0
├─ side-channel@1.0.4
├─ siginfo@2.0.0
├─ slash@3.0.0
├─ slice-ansi@5.0.0
├─ source-map-js@1.0.2
├─ spdx-correct@3.2.0
├─ spdx-exceptions@2.3.0
├─ stackback@0.0.2
├─ string_decoder@1.3.0
├─ string-argv@0.3.2
├─ string.prototype.trim@1.2.7
├─ string.prototype.trimend@1.0.6
├─ string.prototype.trimstart@1.0.6
├─ strip-bom@3.0.0
├─ strip-final-newline@2.0.0
├─ strip-indent@3.0.0
├─ strip-json-comments@3.1.1
├─ strip-literal@1.0.1
├─ supports-preserve-symlinks-flag@1.0.0
├─ test-exclude@6.0.0
├─ text-extensions@1.9.0
├─ text-table@0.2.0
├─ through@2.3.8
├─ time-zone@1.0.0
├─ tinybench@2.5.0
├─ tinypool@0.5.0
├─ tinyspy@2.1.0
├─ to-regex-range@5.0.1
├─ tr46@0.0.3
├─ trim-newlines@3.0.1
├─ ts-node@10.9.1
├─ tsconfig-paths@3.14.2
├─ tslib@1.14.1
├─ tunnel@0.0.6
├─ type-check@0.4.0
├─ type-detect@4.0.8
├─ type-fest@0.20.2
├─ typed-array-length@1.0.4
├─ typescript@5.0.4
├─ ufo@1.1.2
├─ unbox-primitive@1.0.2
├─ util-deprecate@1.0.2
├─ uuid@8.3.2
├─ v8-compile-cache-lib@3.0.1
├─ v8-to-istanbul@9.1.0
├─ vite-node@0.31.1
├─ webidl-conversions@3.0.1
├─ well-known-symbols@2.0.0
├─ whatwg-url@5.0.0
├─ which-boxed-primitive@1.0.2
├─ which-typed-array@1.1.9
├─ which@2.0.2
├─ why-is-node-running@2.2.2
├─ word-wrap@1.2.3
├─ yallist@4.0.0
├─ yaml@2.2.2
├─ yargs-parser@20.2.9
├─ yargs@17.7.2
├─ yn@3.1.1
└─ yocto-queue@1.0.0
Done in 7.75s.
```



</details>
<details>
<summary><em>yarn audit</em></summary>

```Shell
yarn audit v1.22.19
0 vulnerabilities found - Packages audited: 563
Done in 0.79s.
```



</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- package.json
- yarn.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)